### PR TITLE
Add Spotify provider (track, search, analyse)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Get handy information from YouTube and Vimeo videos as well as Discogs releases 
 - https://media.now.sh/discogs/1728315
 - https://media.now.sh/spotify/3S2R0EVwBSAVMd5UMgKTL0
 - https://media.now.sh/spotify/search/thriller michael jackson
+- https://media.now.sh/analyse/3S2R0EVwBSAVMd5UMgKTL0
 
 The data returned will (mostly) be formatted like so:
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,14 @@ You'll need node and yarn (or npm) installed.
 It won't be able to make any requests before the required API keys are defined in an `.env` file. You'll have to create the file yourself and register for API keys as well.
 
 ```
-YOUTUBE_KEY=123
-VIMEO_KEY="Bearer 123"
+YOUTUBE_KEY="123abc"
+VIMEO_KEY="123abc"
+SPOTIFY_CLIENT_ID="123abc"
+SPOTIFY_CLIENT_SECRET="123abc"
 ```
 
 ## Deploying
 
 1. `yarn deploy` (or npm run deploy, if you please)
 2. `now alias insert-now-id-from-above-deploy-here media.now.sh` (the id will be ready to paste automatically)
+

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ Get handy information from YouTube and Vimeo videos as well as Discogs releases 
 - https://media.now.sh/youtube/YyI52_FEYgY
 - https://media.now.sh/vimeo/121814744
 - https://media.now.sh/discogs/1728315
+- https://media.now.sh/spotify/3S2R0EVwBSAVMd5UMgKTL0
+- https://media.now.sh/spotify/search/thriller michael jackson
 
-The data returned will be formatted like so:
+The data returned will (mostly) be formatted like so:
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Get handy information from YouTube and Vimeo videos as well as Discogs releases 
 - https://media.now.sh/vimeo/121814744
 - https://media.now.sh/discogs/1728315
 - https://media.now.sh/spotify/3S2R0EVwBSAVMd5UMgKTL0
-- [https://media.now.sh/spotify/search/Michael Jackson - Thriller](https://media.now.sh/spotify/search/Michael Jackson - Thriller)
 - https://media.now.sh/analyse/3S2R0EVwBSAVMd5UMgKTL0
+- [https://media.now.sh/spotify-search/Michael Jackson - Thriller](https://media.now.sh/spotify-search/Michael Jackson - Thriller)
 
 The data returned will (mostly) be formatted like so:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Get handy information from YouTube and Vimeo videos as well as Discogs releases 
 - https://media.now.sh/vimeo/121814744
 - https://media.now.sh/discogs/1728315
 - https://media.now.sh/spotify/3S2R0EVwBSAVMd5UMgKTL0
-- https://media.now.sh/spotify/search/thriller michael jackson
+- [https://media.now.sh/spotify/search/Michael Jackson - Thriller](https://media.now.sh/spotify/search/Michael Jackson - Thriller)
 - https://media.now.sh/analyse/3S2R0EVwBSAVMd5UMgKTL0
 
 The data returned will (mostly) be formatted like so:

--- a/index.js
+++ b/index.js
@@ -5,9 +5,14 @@ const youtube = require('./src/serializer-youtube')
 const vimeo = require('./src/serializer-vimeo')
 const discogs = require('./src/serializer-discogs')
 const spotify = require('./src/serializer-spotify')
+const spotifySearch = require('./src/serializer-spotify-search')
 const analyse = require('./src/serializer-analyse')
 
-const serializers = {youtube, vimeo, discogs, spotify, analyse}
+const serializers = {
+	youtube, vimeo, discogs, spotify,
+	'spotify-search': spotifySearch,
+	analyse
+}
 const cors = microCors({allowMethods: ['GET']})
 
 module.exports = cors(async (request, response) => {

--- a/index.js
+++ b/index.js
@@ -4,12 +4,12 @@ const microCors = require('micro-cors')
 const youtube = require('./src/serializer-youtube')
 const vimeo = require('./src/serializer-vimeo')
 const discogs = require('./src/serializer-discogs')
+const spotify = require('./src/serializer-spotify')
 
-const serializers = {youtube, vimeo, discogs}
-
+const serializers = {youtube, vimeo, discogs, spotify}
 const cors = microCors({allowMethods: ['GET']})
+
 module.exports = cors(async (request, response) => {
-	// An URL as `domain.com/youtube/id` is expected.
 	let args = request.url.split('/')
 	let provider = args[1]
 	let id = args[2]

--- a/index.js
+++ b/index.js
@@ -5,8 +5,9 @@ const youtube = require('./src/serializer-youtube')
 const vimeo = require('./src/serializer-vimeo')
 const discogs = require('./src/serializer-discogs')
 const spotify = require('./src/serializer-spotify')
+const analyse = require('./src/serializer-analyse')
 
-const serializers = {youtube, vimeo, discogs, spotify}
+const serializers = {youtube, vimeo, discogs, spotify, analyse}
 const cors = microCors({allowMethods: ['GET']})
 
 module.exports = cors(async (request, response) => {

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = cors(async (request, response) => {
 	}
 
 	// Fetch the data, convert to json, extract what we need.
-	let data = await serializer.fetchData(id)
+	let data = await serializer.fetchData(id, args)
 	let json = await data.json()
 	return serializer.serialize(json)
 })

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = cors(async (request, response) => {
 	}
 
 	// Fetch the data, convert to json, extract what we need.
-	let data = await serializer.fetchData(id, args)
+	let data = await serializer.fetchData(id)
 	let json = await data.json()
 	return serializer.serialize(json)
 })

--- a/package.json
+++ b/package.json
@@ -8,21 +8,22 @@
   "license": "MIT",
   "scripts": {
     "start": "nodemon --exec 'micro .'",
+    "now-start": "micro .",
     "test": "xo && ava",
-    "deploy": "sed 's/^/-e /' .env | xargs now"
+    "deploy": "sed 's/^/-e /' .env | xargs now -e NODE_ENV=production"
   },
   "dependencies": {
+    "dotenv": "^4.0.0",
     "isomorphic-fetch": "^2.2.1",
     "micro": "^6.2.0",
     "micro-cors": "^0.0.1",
-    "nodemon": "^1.11.0",
     "pomeranian-durations": "^0.1.4",
     "request": "^2.79.0",
     "request-promise-native": "^1.0.3"
   },
   "devDependencies": {
     "ava": "^0.18.1",
-    "dotenv": "^4.0.0",
+    "nodemon": "^1.11.0",
     "test-listen": "^1.0.1",
     "xo": "^0.17.1"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "micro": "^6.2.0",
     "micro-cors": "^0.0.1",
     "nodemon": "^1.11.0",
-    "pomeranian-durations": "^0.1.4"
+    "pomeranian-durations": "^0.1.4",
+    "request": "^2.79.0",
+    "request-promise-native": "^1.0.3"
   },
   "devDependencies": {
     "ava": "^0.18.1",

--- a/src/serializer-analyse.js
+++ b/src/serializer-analyse.js
@@ -48,7 +48,7 @@ const fetchData = async function (id) {
 const serialize = function (json) {
 	json.provider = 'analyse'
 	json.mediaNow = {
-		spotify: `http://localhost:3000/spotify/${json.id}`
+		spotify: `https://media.now.sh/spotify/${json.id}`
 	}
 	return json
 }

--- a/src/serializer-analyse.js
+++ b/src/serializer-analyse.js
@@ -1,0 +1,51 @@
+const fetch = require('isomorphic-fetch')
+const rp = require('request-promise-native')
+
+const clientId = process.env.SPOTIFY_CLIENT_ID
+const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
+
+// Send a request to spotify with our client id and secret
+// to get an access token back. A token is required for certain
+// Spotify API endpoints. Like audio-analysis.
+const requestAccessToken = async function (id, secret) {
+	if (!id || !secret) {
+		throw new Error('Missing Spotify secrets. Check your .env file')
+	}
+
+	let auth = new Buffer(`${id}:${secret}`).toString('base64')
+
+	let options = {
+		url: 'https://accounts.spotify.com/api/token',
+		headers: {
+			Authorization: 'Basic ' + (auth)
+		},
+		form: {
+			grant_type: 'client_credentials' // eslint-disable-line camelcase
+		},
+		json: true
+	}
+
+	// Using a promise-version of the request module,
+	// because I couldn't configure node-fetch to send the request correctly.
+	return await rp.post(options)
+}
+
+const fetchData = async function (id) {
+	let token = await requestAccessToken(clientId, clientSecret)
+	let url = `https://api.spotify.com/v1/audio-features/${id}`
+	// let url = `https://api.spotify.com/v1/audio-analysis/${id}`
+
+	return await fetch(url, {
+		headers: {
+			Authorization: 'Bearer ' + token.access_token
+		}
+	})
+}
+
+const serialize = function (json) {
+	return json
+}
+
+module.exports.fetchData = fetchData
+module.exports.serialize = serialize
+

--- a/src/serializer-analyse.js
+++ b/src/serializer-analyse.js
@@ -7,6 +7,8 @@ const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
 // Send a request to spotify with our client id and secret
 // to get an access token back. A token is required for certain
 // Spotify API endpoints. Like audio-analysis.
+// Because I couldn't configure node-fetch to send the request correctly,
+// we're using request here instead of fetch.
 const requestAccessToken = async function (id, secret) {
 	if (!id || !secret) {
 		throw new Error('Missing Spotify secrets. Check your .env file')
@@ -25,8 +27,6 @@ const requestAccessToken = async function (id, secret) {
 		json: true
 	}
 
-	// Using a promise-version of the request module,
-	// because I couldn't configure node-fetch to send the request correctly.
 	return await rp.post(options)
 }
 

--- a/src/serializer-analyse.js
+++ b/src/serializer-analyse.js
@@ -1,6 +1,9 @@
 const fetch = require('isomorphic-fetch')
 const rp = require('request-promise-native')
 
+// This serializer provides audio-analysis for Spotify tracks.
+// Currently using https://developer.spotify.com/web-api/get-audio-features/.
+
 const clientId = process.env.SPOTIFY_CLIENT_ID
 const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
 
@@ -43,6 +46,10 @@ const fetchData = async function (id) {
 }
 
 const serialize = function (json) {
+	json.provider = 'analyse'
+	json.mediaNow = {
+		spotify: `http://localhost:3000/spotify/${json.id}`
+	}
 	return json
 }
 

--- a/src/serializer-spotify-search.js
+++ b/src/serializer-spotify-search.js
@@ -37,8 +37,8 @@ const serializeMany = items => items.map(item => {
 		id: item.id,
 		title: `${item.artists[0].name} - ${item.name}`,
 		mediaNow: {
-			spotify: `http://localhost:3000/spotify/${item.id}`,
-			analyse: `http://localhost:3000/analyse/${item.id}`
+			spotify: `https://media.now.sh/spotify/${item.id}`,
+			analyse: `https://media.now.sh/analyse/${item.id}`
 		}
 	}
 })

--- a/src/serializer-spotify-search.js
+++ b/src/serializer-spotify-search.js
@@ -1,0 +1,56 @@
+const fetch = require('isomorphic-fetch')
+
+// Take a query like "Artist - Track title"
+// and return {artist, title}
+const splitQuery = query => {
+	let q = decodeURI(query)
+	if (!q.includes(' - ')) {
+		return false
+	}
+	let [artist, ...track] = q.split(' - ')
+	track = track.join(' - ')
+	return {artist, track}
+}
+
+const buildURL = function (query) {
+	const endpoint = `https://api.spotify.com/v1/search`
+	const type = 'track'
+	const limit = 10
+
+	// Spotify returns much more precise results when
+	// artist and track are specified seperately.
+	let info = splitQuery(query)
+	if (info.artist && info.track) {
+		query = `artist:${info.artist}+track:${info.track}`
+	}
+
+	return `${endpoint}?limit=${limit}&type=${type}&q=${query}`
+}
+
+const fetchData = async function (id) {
+	return await fetch(buildURL(id))
+}
+
+const serializeMany = items => items.map(item => {
+	return {
+		provider: 'spotify',
+		id: item.id,
+		title: `${item.artists[0].name} - ${item.name}`,
+		mediaNow: {
+			spotify: `http://localhost:3000/spotify/${item.id}`,
+			analyse: `http://localhost:3000/analyse/${item.id}`
+		}
+	}
+})
+
+const serialize = function (json) {
+	// return json // use this to debug
+	if (json.tracks && json.tracks.items.length > 0) {
+		return serializeMany(json.tracks.items)
+	}
+	return {error: 'no results'}
+}
+
+module.exports.fetchData = fetchData
+module.exports.serialize = serialize
+

--- a/src/serializer-spotify.js
+++ b/src/serializer-spotify.js
@@ -1,37 +1,56 @@
 const fetch = require('isomorphic-fetch')
 
-// https://api.spotify.com/v1/search?type=track&q=Hugh%20Masekela%20-%20Don%27t%20Go%20Lose%20It%20Baby
 const buildURL = function (query) {
 	const type = 'track'
-	const limit = 3
-	return `https://api.spotify.com/v1/search?type=${type}&query=${query}&limit=${limit}`
+	const limit = 10
+	const endpoint = `https://api.spotify.com/v1/search`
+	return `${endpoint}?q=track:${query}&limit=${limit}&type=${type}&`
 }
 
-const fetchData = async function (id) {
-	return await fetch(buildURL(id))
-}
-
-const serialize = function (json) {
-	if (!json.tracks.items.length) {
-		throw new Error('No JSON items to work with')
+const fetchData = async function (id, args) {
+	if (id === 'search') {
+		console.log(args)
+		let query = args[3]
+		return await fetch(buildURL(query))
 	}
+	return await fetch(`https://api.spotify.com/v1/tracks/${id}`)
+}
 
-	const item = json.tracks.items[0]
-	// return item // use this to debug
+const serializeOne = item => ({
+	provider: 'spotify',
+	id: item.id,
+	url: item.external_urls.spotify,
+	title: `${item.artists[0].name} - ${item.name}`,
+	thumbnail: item.album.images[1].url,
+	duration: (item.duration_ms / 1000),
+	extras: {
+		isrc: item.external_ids.isrc,
+		popularity: item.popularity,
+		previewUrl: item.preview_url,
+		_analysis: `http://localhost:3000/analyse/${item.id}`
+	}
+})
 
+const serializeMany = items => items.map(item => {
+	// return serializeOne(item)
 	return {
 		provider: 'spotify',
 		id: item.id,
-		duration: (item.duration_ms / 1000),
-		url: item.external_urls.spotify,
 		title: `${item.artists[0].name} - ${item.name}`,
-		thumbnail: item.album.images[1].url,
-		extras: {
-			isrc: item.external_ids.isrc,
-			popularity: item.popularity,
-			preview_url: item.preview_url
-		}
+		_spotify: `http://localhost:3000/spotify/${item.id}`
 	}
+})
+
+const serialize = function (json) {
+	// return json // use this to debug
+
+	// If we have items, assume it was a search.
+	if (json.tracks && json.tracks.items.length > 0) {
+		return serializeMany(json.tracks.items)
+	}
+
+	// Otherwise it was a single track.
+	return serializeOne(json)
 }
 
 module.exports.fetchData = fetchData

--- a/src/serializer-spotify.js
+++ b/src/serializer-spotify.js
@@ -17,7 +17,7 @@ const serializeOne = item => ({
 		previewUrl: item.preview_url
 	},
 	mediaNow: {
-		analyse: `http://localhost:3000/analyse/${item.id}`
+		analyse: `https://media.now.sh/analyse/${item.id}`
 	}
 })
 

--- a/src/serializer-spotify.js
+++ b/src/serializer-spotify.js
@@ -9,7 +9,6 @@ const buildURL = function (query) {
 
 const fetchData = async function (id, args) {
 	if (id === 'search') {
-		console.log(args)
 		let query = args[3]
 		return await fetch(buildURL(query))
 	}

--- a/src/serializer-spotify.js
+++ b/src/serializer-spotify.js
@@ -1,37 +1,6 @@
 const fetch = require('isomorphic-fetch')
 
-// Take a query like "Artist - Track title"
-// and return {artist, title}
-const splitQuery = query => {
-	let q = decodeURI(query)
-	if (!q.includes(' - ')) {
-		return false
-	}
-	let [artist, ...track] = q.split(' - ')
-	track = track.join(' - ')
-	return {artist, track}
-}
-
-const buildURL = function (query) {
-	const endpoint = `https://api.spotify.com/v1/search`
-	const type = 'track'
-	const limit = 10
-
-	// Spotify returns much more precise results when
-	// artist and track are specified seperately.
-	let info = splitQuery(query)
-	if (info.artist && info.track) {
-		query = `artist:${info.artist}+track:${info.track}`
-	}
-
-	return `${endpoint}?limit=${limit}&type=${type}&q=${query}`
-}
-
-const fetchData = async function (id, args) {
-	if (id === 'search') {
-		let query = args[3]
-		return await fetch(buildURL(query))
-	}
+const fetchData = async function (id) {
 	return await fetch(`https://api.spotify.com/v1/tracks/${id}`)
 }
 
@@ -52,27 +21,8 @@ const serializeOne = item => ({
 	}
 })
 
-const serializeMany = items => items.map(item => {
-	return {
-		provider: 'spotify',
-		id: item.id,
-		title: `${item.artists[0].name} - ${item.name}`,
-		mediaNow: {
-			spotify: `http://localhost:3000/spotify/${item.id}`,
-			analyse: `http://localhost:3000/analyse/${item.id}`
-		}
-	}
-})
-
 const serialize = function (json) {
 	// return json // use this to debug
-
-	// If we have items, assume it was a search.
-	if (json.tracks && json.tracks.items.length > 0) {
-		return serializeMany(json.tracks.items)
-	}
-
-	// Otherwise it was a single track.
 	if (json.id) {
 		return serializeOne(json)
 	}

--- a/src/serializer-spotify.js
+++ b/src/serializer-spotify.js
@@ -1,0 +1,39 @@
+const fetch = require('isomorphic-fetch')
+
+// https://api.spotify.com/v1/search?type=track&q=Hugh%20Masekela%20-%20Don%27t%20Go%20Lose%20It%20Baby
+const buildURL = function (query) {
+	const type = 'track'
+	const limit = 3
+	return `https://api.spotify.com/v1/search?type=${type}&query=${query}&limit=${limit}`
+}
+
+const fetchData = async function (id) {
+	return await fetch(buildURL(id))
+}
+
+const serialize = function (json) {
+	if (!json.tracks.items.length) {
+		throw new Error('No JSON items to work with')
+	}
+
+	const item = json.tracks.items[0]
+	// return item // use this to debug
+
+	return {
+		provider: 'spotify',
+		id: item.id,
+		duration: (item.duration_ms / 1000),
+		url: item.external_urls.spotify,
+		title: `${item.artists[0].name} - ${item.name}`,
+		thumbnail: item.album.images[1].url,
+		extras: {
+			isrc: item.external_ids.isrc,
+			popularity: item.popularity,
+			preview_url: item.preview_url
+		}
+	}
+}
+
+module.exports.fetchData = fetchData
+module.exports.serialize = serialize
+

--- a/src/serializer-spotify.js
+++ b/src/serializer-spotify.js
@@ -45,18 +45,22 @@ const serializeOne = item => ({
 	extras: {
 		isrc: item.external_ids.isrc,
 		popularity: item.popularity,
-		previewUrl: item.preview_url,
-		_analysis: `http://localhost:3000/analyse/${item.id}`
+		previewUrl: item.preview_url
+	},
+	mediaNow: {
+		analyse: `http://localhost:3000/analyse/${item.id}`
 	}
 })
 
 const serializeMany = items => items.map(item => {
-	// return serializeOne(item)
 	return {
 		provider: 'spotify',
 		id: item.id,
 		title: `${item.artists[0].name} - ${item.name}`,
-		_spotify: `http://localhost:3000/spotify/${item.id}`
+		mediaNow: {
+			spotify: `http://localhost:3000/spotify/${item.id}`,
+			analyse: `http://localhost:3000/analyse/${item.id}`
+		}
 	}
 })
 

--- a/src/serializer-spotify.js
+++ b/src/serializer-spotify.js
@@ -1,10 +1,30 @@
 const fetch = require('isomorphic-fetch')
 
+// Take a query like "Artist - Track title"
+// and return {artist, title}
+const splitQuery = query => {
+	let q = decodeURI(query)
+	if (!q.includes(' - ')) {
+		return false
+	}
+	let [artist, ...track] = q.split(' - ')
+	track = track.join(' - ')
+	return {artist, track}
+}
+
 const buildURL = function (query) {
+	const endpoint = `https://api.spotify.com/v1/search`
 	const type = 'track'
 	const limit = 10
-	const endpoint = `https://api.spotify.com/v1/search`
-	return `${endpoint}?q=track:${query}&limit=${limit}&type=${type}&`
+
+	// Spotify returns much more precise results when
+	// artist and track are specified seperately.
+	let info = splitQuery(query)
+	if (info.artist && info.track) {
+		query = `artist:${info.artist}+track:${info.track}`
+	}
+
+	return `${endpoint}?limit=${limit}&type=${type}&q=${query}`
 }
 
 const fetchData = async function (id, args) {
@@ -49,7 +69,10 @@ const serialize = function (json) {
 	}
 
 	// Otherwise it was a single track.
-	return serializeOne(json)
+	if (json.id) {
+		return serializeOne(json)
+	}
+	return {error: 'no results'}
 }
 
 module.exports.fetchData = fetchData

--- a/test.js
+++ b/test.js
@@ -65,22 +65,26 @@ test('spotify provider', async t => {
 	const json = await body.json()
 	t.is(body.status, 200)
 	verifyProvider(t, provider, id, json)
+	t.truthy(json.mediaNow)
 })
 
 test('spotify provider search', async t => {
 	let provider = 'spotify'
-	let query = 'thriller michael jackson'
+	let query = 'Michael Jackson - Thriller'
 	const url = await listen(micro(mediaNow))
 	const body = await fetch(`${url}/${provider}/search/${query}`)
 	const json = await body.json()
 	const item = json[0]
+
 	t.is(body.status, 200)
+
 	t.is(item.provider, provider)
 	t.truthy(item.id)
 	t.truthy(item.title)
-	// test if title contains words from the query?
-	// item.title.search(new RegExp('thriller', 'i'))
-	let firstWordIsIncluded = item.title.toLowerCase().includes(query.split(' ')[0])
+	t.truthy(item.mediaNow)
+
+	let firstWord = query.split(' ')[0].toLowerCase()
+	let firstWordIsIncluded = item.title.toLowerCase().includes(firstWord)
 	t.true(firstWordIsIncluded)
 })
 

--- a/test.js
+++ b/test.js
@@ -74,7 +74,6 @@ test('spotify-search provider', async t => {
 	const url = await listen(micro(mediaNow))
 	const body = await fetch(`${url}/${provider}/${query}`)
 	const json = await body.json()
-	console.log(json)
 	const item = json[0]
 	t.is(body.status, 200)
 	t.is(item.provider, 'spotify')

--- a/test.js
+++ b/test.js
@@ -60,3 +60,29 @@ test('discogs provider', async t => {
 	t.truthy(json.year)
 })
 
+test('spotify provider', async t => {
+	let provider = 'spotify'
+	let id = '20efeySIfZoiSaISGLBbNs'
+	const url = await listen(micro(mediaNow))
+	const body = await fetch(`${url}/${provider}/${id}`)
+	const json = await body.json()
+	t.is(body.status, 200)
+	verifyProvider(t, provider, id, json)
+})
+
+test('spotify search', async t => {
+	let provider = 'spotify'
+	let query = 'thriller michael jackson'
+	const url = await listen(micro(mediaNow))
+	const body = await fetch(`${url}/${provider}/search/${query}`)
+	const json = await body.json()
+	const item = json[0]
+	t.is(body.status, 200)
+	t.is(item.provider, provider)
+	t.truthy(item.id)
+	t.truthy(item.title)
+	// test if title contains words from the query?
+	// item.title.search(new RegExp('thriller', 'i'))
+	let firstWordIsIncluded = item.title.toLowerCase().includes(query.split(' ')[0])
+	t.true(firstWordIsIncluded)
+})

--- a/test.js
+++ b/test.js
@@ -5,8 +5,7 @@ const fetch = require('isomorphic-fetch')
 const mediaNow = require('./index')
 
 test('the server runs and returns a 404 error message', async t => {
-	const service = micro(mediaNow)
-	const url = await listen(service)
+	const url = await listen(micro(mediaNow))
 	const body = await fetch(url)
 	const json = await body.json()
 	t.is(body.status, 404)
@@ -35,8 +34,7 @@ test('youtube provider', async t => {
 test('vimeo provider', async t => {
 	let provider = 'vimeo'
 	let id = '121814744'
-	const service = micro(mediaNow)
-	const url = await listen(service)
+	const url = await listen(micro(mediaNow))
 	const body = await fetch(`${url}/${provider}/${id}`)
 	const json = await body.json()
 	t.is(body.status, 200)
@@ -46,8 +44,7 @@ test('vimeo provider', async t => {
 test('discogs provider', async t => {
 	let provider = 'discogs'
 	let id = 1728315
-	const service = micro(mediaNow)
-	const url = await listen(service)
+	const url = await listen(micro(mediaNow))
 	const body = await fetch(`${url}/${provider}/${id}`)
 	const json = await body.json()
 	t.is(body.status, 200)
@@ -70,7 +67,7 @@ test('spotify provider', async t => {
 	verifyProvider(t, provider, id, json)
 })
 
-test('spotify search', async t => {
+test('spotify provider search', async t => {
 	let provider = 'spotify'
 	let query = 'thriller michael jackson'
 	const url = await listen(micro(mediaNow))
@@ -86,3 +83,4 @@ test('spotify search', async t => {
 	let firstWordIsIncluded = item.title.toLowerCase().includes(query.split(' ')[0])
 	t.true(firstWordIsIncluded)
 })
+

--- a/test.js
+++ b/test.js
@@ -68,21 +68,19 @@ test('spotify provider', async t => {
 	t.truthy(json.mediaNow)
 })
 
-test('spotify provider search', async t => {
-	let provider = 'spotify'
+test('spotify-search provider', async t => {
+	let provider = 'spotify-search'
 	let query = 'Michael Jackson - Thriller'
 	const url = await listen(micro(mediaNow))
-	const body = await fetch(`${url}/${provider}/search/${query}`)
+	const body = await fetch(`${url}/${provider}/${query}`)
 	const json = await body.json()
+	console.log(json)
 	const item = json[0]
-
 	t.is(body.status, 200)
-
-	t.is(item.provider, provider)
+	t.is(item.provider, 'spotify')
 	t.truthy(item.id)
 	t.truthy(item.title)
 	t.truthy(item.mediaNow)
-
 	let firstWord = query.split(' ')[0].toLowerCase()
 	let firstWordIsIncluded = item.title.toLowerCase().includes(firstWord)
 	t.true(firstWordIsIncluded)

--- a/test.js
+++ b/test.js
@@ -88,3 +88,16 @@ test('spotify provider search', async t => {
 	t.true(firstWordIsIncluded)
 })
 
+test('analyse provider', async t => {
+	let provider = 'analyse'
+	let id = '20efeySIfZoiSaISGLBbNs'
+	const url = await listen(micro(mediaNow))
+	const body = await fetch(`${url}/${provider}/${id}`)
+	const json = await body.json()
+	t.is(body.status, 200)
+	t.truthy(json.mediaNow)
+	t.truthy(json.energy)
+	t.truthy(json.tempo)
+	t.truthy(json.valence)
+	t.truthy(json.danceability)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -3078,6 +3078,19 @@ req-all@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/req-all/-/req-all-0.1.0.tgz#130051e2ace58a02eacbfc9d448577a736a9273a"
 
+request-promise-core@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
+  dependencies:
+    lodash "^4.13.1"
+
+request-promise-native@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.3.tgz#9cb2b2f69f137e4acf35116a08a441cbfd0c0134"
+  dependencies:
+    request-promise-core "1.1.1"
+    stealthy-require "^1.0.0"
+
 request@^2.79.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
@@ -3268,6 +3281,10 @@ sshpk@^1.7.0:
 stack-utils@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-0.4.0.tgz#940cb82fccfa84e8ff2f3fdf293fe78016beccd1"
+
+stealthy-require@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.0.0.tgz#1a8ed8fc19a8b56268f76f5a1a3e3832b0c26200"
 
 stream-combiner@~0.0.4:
   version "0.0.4"


### PR DESCRIPTION
This adds two three endpoints.

- `/spotify/:id`
- `/spotify/search/:query`
- `/analyse/:spotify_id`

The search isn't optimal and will need tweaking. For instance, "Michael Jackson - Thriller" won't give you the results you want but "thriller michael jackson" will. This is because it currently reads the query as the song title. Spotify supports searching in everything or filtered to title, artist and album so I should think we can tweak it until it works as expected.