### PR TITLE
Feature/show privacy status

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ The data returned will (mostly) be formatted like so:
 	"url": "https://www.youtube.com/watch?v=YyI52_FEYgY",
 	"title": "I Due Nemici",
 	"thumbnail": "https://i.ytimg.com/vi/YyI52_FEYgY/default.jpg",
-	"duration": 6300 // seconds
+	"duration": 6300 // seconds,
+	"status" {} // privacy info, is it embeddable etc.
 }
 ```
 

--- a/src/serializer-youtube.js
+++ b/src/serializer-youtube.js
@@ -4,7 +4,7 @@ const {asSeconds} = require('pomeranian-durations')
 const key = process.env.YOUTUBE_KEY
 
 const buildURL = function (id) {
-	return `https://www.googleapis.com/youtube/v3/videos?part=contentDetails,snippet&id=${id}&key=${key}`
+	return `https://www.googleapis.com/youtube/v3/videos?part=status,contentDetails,snippet&id=${id}&key=${key}`
 }
 
 const fetchData = async function (id) {
@@ -16,7 +16,7 @@ const fetchData = async function (id) {
 
 const serialize = function (json) {
 	if (json.items.length === 0) {
-		throw new Error('No JSON items to work with')
+		throw new Error('No video found')
 	}
 
 	const item = json.items[0]
@@ -26,16 +26,21 @@ const serialize = function (json) {
 		provider: 'youtube',
 		id: item.id,
 		url: `https://www.youtube.com/watch?v=${item.id}`,
+
+		// requires ?part=snippet
 		title: item.snippet.title,
 		thumbnail: item.snippet.thumbnails.default.url,
 
-		// Once date-fns supports durations let's switch to that.
+		// requires ?part=contentDetails
 		// See https://github.com/date-fns/date-fns/pull/348
-		duration: asSeconds(item.contentDetails.duration)
+		// Once date-fns supports durations let's switch to that.
+		duration: asSeconds(item.contentDetails.duration),
 
-		// To get privacy info: set part=status --> item.status.embeddable = boolean
+		// requires ?part=status
+		status: item.status
 	}
 }
 
 module.exports.fetchData = fetchData
 module.exports.serialize = serialize
+

--- a/test.js
+++ b/test.js
@@ -29,6 +29,7 @@ test('youtube provider', async t => {
 	const json = await body.json()
 	t.is(body.status, 200)
 	verifyProvider(t, provider, id, json)
+	t.truthy(json.status, 'it includes privacy status info')
 })
 
 test('vimeo provider', async t => {


### PR DESCRIPTION
This adds a new `status` field to the YouTube serializer. Example:

```json
{
"provider": "youtube",
"id": "-Op4D4bkK6Y",
"url": "https://www.youtube.com/watch?v=-Op4D4bkK6Y",
"title": "Dizzy K \"No Dime\"",
"thumbnail": "https://i.ytimg.com/vi/-Op4D4bkK6Y/default.jpg",
"duration": 349,
"status": {
  "uploadStatus": "processed",
  "privacyStatus": "public",
  "license": "youtube",
  "embeddable": true,
  "publicStatsViewable": true
}
}
```