### PR TITLE
Add "file" provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .DS_Store
 .claude/
 .sprite
+CLAUDE.local.md

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Media Now
 
-Parse URLs to extract provider and identifier. Fetch metadata from YouTube, Vimeo, Spotify, Discogs, MusicBrainz, and SoundCloud. No API keys.
+Parse URLs to extract provider and identifier. Fetch metadata from YouTube, Vimeo, Spotify, Discogs, MusicBrainz, SoundCloud, and direct audio/video files. No API keys.
 
 Meant to be useful for people dealing with music tracks in one shape or another (hello https://radio4000.com).
 
@@ -19,6 +19,9 @@ parseTitle('Nikolaj Nørlund - Hvid røg og tekno')
 
 parseUrl('https://vimeo.com/123456789')
 // { provider: 'vimeo', id: '123456789' }
+
+parseUrl('https://example.com/song.mp3')
+// { provider: 'file', id: 'https://example.com/song.mp3', kind: 'audio' }
 
 await getMedia('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
 // { provider, id, url, title, thumbnail, author, payload }
@@ -38,6 +41,7 @@ import { spotify } from 'media-now/providers/spotify'
 import { discogs } from 'media-now/providers/discogs'
 import { musicbrainz } from 'media-now/providers/musicbrainz'
 import { soundcloud } from 'media-now/providers/soundcloud'
+import { file } from 'media-now/providers/file'
 
 youtube.fetch(id)              // ~100ms - basic metadata via oEmbed
 youtube.fetchExtended(id)      // ~1s - includes music card data (song, artist, album)
@@ -50,6 +54,7 @@ discogs.fetchMaster(id)
 musicbrainz.search(query)
 musicbrainz.fetchRecording(id)
 musicbrainz.fetchRelease(id)
+file.fetch(url, kind)          // kind is 'audio' or 'video', title extracted from filename
 ```
 
 ## Development

--- a/demo/index.html
+++ b/demo/index.html
@@ -18,6 +18,8 @@
       <button data-url="https://open.spotify.com/track/4cOdK2wGLETKBW3PvgPWqT">Spotify</button>
       <button data-url="https://www.discogs.com/release/249504">Discogs</button>
       <button data-url="https://soundcloud.com/rick-astley-official/never-gonna-give-you-up">SoundCloud</button>
+      <button data-url="https://cdn.freesound.org/previews/612/612095_5674468-lq.mp3">Audio file</button>
+      <button data-url="https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/360/Big_Buck_Bunny_360_10s_1MB.mp4">Video file</button>
     </div>
     <input type="url" id="parseurl-input" value="https://www.youtube.com/watch?v=dQw4w9WgXcQ">
     <button id="parseurl-btn">Parse</button>
@@ -46,6 +48,8 @@
       <button data-url="https://open.spotify.com/track/4cOdK2wGLETKBW3PvgPWqT">Spotify</button>
       <button data-url="https://www.discogs.com/release/249504">Discogs</button>
       <button data-url="https://soundcloud.com/rick-astley-official/never-gonna-give-you-up">SoundCloud</button>
+      <button data-url="https://cdn.freesound.org/previews/612/612095_5674468-lq.mp3">Audio file</button>
+      <button data-url="https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/360/Big_Buck_Bunny_360_10s_1MB.mp4">Video file</button>
     </div>
     <input type="url" id="getmedia-input" value="https://www.youtube.com/watch?v=dQw4w9WgXcQ">
     <button id="getmedia-btn">Fetch</button>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "media-now",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Fetch media information from YouTube, Vimeo, Spotify and Discogs",
   "repository": {
     "type": "git",

--- a/src/get-media.ts
+++ b/src/get-media.ts
@@ -5,6 +5,7 @@
 import { ProviderError } from './errors'
 import { type ParsedUrl, parseUrl } from './parse-url'
 import { discogs } from './providers/discogs'
+import { file } from './providers/file'
 import { soundcloud } from './providers/soundcloud'
 import { spotify } from './providers/spotify'
 import { vimeo } from './providers/vimeo'
@@ -22,6 +23,7 @@ const providers: Record<
 	discogs: discogs.fetch,
 	musicbrainz: null, // MusicBrainz is lookup-only, not URL-based
 	soundcloud: soundcloud.fetch,
+	file: file.fetch,
 }
 
 /**

--- a/src/parse-url.test.ts
+++ b/src/parse-url.test.ts
@@ -295,6 +295,60 @@ describe('parseUrl', () => {
 		})
 	})
 
+	describe('File (audio)', () => {
+		const audioUrls: [string, string][] = [
+			['https://example.com/song.mp3', '.mp3'],
+			['https://cdn.example.com/music/track.flac', '.flac'],
+			['https://example.com/audio.ogg', '.ogg'],
+			['https://example.com/sample.wav', '.wav'],
+			['https://example.com/podcast.m4a', '.m4a'],
+			['https://example.com/voice.opus', '.opus'],
+			['https://cdn.example.com/file.mp3?token=abc', '.mp3 with query params'],
+			['https://example.com/my%20song.mp3', 'URL-encoded path'],
+		]
+
+		it.each(audioUrls)('parses %s (%s)', (url) => {
+			const result = parseUrl(url)
+			expect(result?.provider).toBe('file')
+			expect(result?.kind).toBe('audio')
+			expect(result?.id).toBe(url)
+		})
+
+		it('parses audio URLs without protocol', () => {
+			const result = parseUrl('example.com/song.mp3')
+			expect(result?.provider).toBe('file')
+			expect(result?.kind).toBe('audio')
+		})
+
+		it('parses audio URLs with fragment', () => {
+			const result = parseUrl('https://example.com/song.mp3#t=10')
+			expect(result?.provider).toBe('file')
+			expect(result?.kind).toBe('audio')
+		})
+	})
+
+	describe('File (video)', () => {
+		const videoUrls: [string, string][] = [
+			['https://example.com/clip.mp4', '.mp4'],
+			['https://cdn.example.com/video.webm', '.webm'],
+			['https://example.com/movie.ogv', '.ogv'],
+			['https://cdn.example.com/video.mp4?token=abc', '.mp4 with query params'],
+		]
+
+		it.each(videoUrls)('parses %s (%s)', (url) => {
+			const result = parseUrl(url)
+			expect(result?.provider).toBe('file')
+			expect(result?.kind).toBe('video')
+			expect(result?.id).toBe(url)
+		})
+
+		it('rejects non-media files', () => {
+			expect(parseUrl('https://example.com/image.jpg')).toBeNull()
+			expect(parseUrl('https://example.com/document.pdf')).toBeNull()
+			expect(parseUrl('https://example.com/style.css')).toBeNull()
+		})
+	})
+
 	describe('Edge cases', () => {
 		it('returns null for invalid URLs', () => {
 			expect(parseUrl('not a url')).toBeNull()

--- a/src/parse-url.ts
+++ b/src/parse-url.ts
@@ -26,7 +26,8 @@ export const parseUrl = (url: string): ParsedUrl | null => {
 			parseVimeo(parsed) ??
 			parseSpotify(parsed) ??
 			parseDiscogs(parsed) ??
-			parseSoundCloud(parsed)
+			parseSoundCloud(parsed) ??
+			parseFile(parsed)
 		)
 	} catch {
 		return null
@@ -178,4 +179,37 @@ const parseSoundCloud = (url: URL): ParsedUrl | null => {
 
 	// The ID is username/track-slug
 	return { provider: 'soundcloud', id: `${username}/${trackSlug}` }
+}
+
+/** Audio file extensions */
+const AUDIO_EXT_RE =
+	/\.(mp3|m4a|aac|mid|midi|ogg|oga|wav|flac|opus|weba)(?:$|[?#])/i
+
+/** Video file extensions (browser-playable formats) */
+const VIDEO_EXT_RE = /\.(mp4|webm|ogv)(?:$|[?#])/i
+
+/**
+ * Parse direct audio/video file URLs (self-hosted, CDN, etc.)
+ * The ID is the full URL since there's no extractable media ID.
+ */
+const parseFile = (url: URL): ParsedUrl | null => {
+	const href = url.href
+	let decodedPathname: string | undefined
+	try {
+		decodedPathname = decodeURIComponent(url.pathname)
+	} catch {
+		// ignore decode errors
+	}
+
+	// Check audio first, then video
+	for (const [re, kind] of [
+		[AUDIO_EXT_RE, 'audio'],
+		[VIDEO_EXT_RE, 'video'],
+	] as const) {
+		if (re.test(href)) return { provider: 'file', id: href, kind }
+		if (decodedPathname && re.test(decodedPathname))
+			return { provider: 'file', id: href, kind }
+	}
+
+	return null
 }

--- a/src/providers/file.ts
+++ b/src/providers/file.ts
@@ -1,0 +1,16 @@
+/**
+ * File provider — handles direct audio/video URLs
+ */
+
+import type { FileResult } from '../types'
+
+export const file = {
+	fetch: async (id: string, kind?: string): Promise<FileResult> => ({
+		provider: 'file',
+		id,
+		url: id,
+		title: id,
+		kind: (kind as 'audio' | 'video') || 'audio',
+		payload: null,
+	}),
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export type Provider =
 	| 'discogs'
 	| 'musicbrainz'
 	| 'soundcloud'
+	| 'file'
 
 /** Base interface for all media results */
 export interface MediaResult {
@@ -96,6 +97,13 @@ export interface SoundCloudResult extends MediaResult {
 	thumbnail?: string
 	author: string
 	description?: string
+}
+
+/** Direct file media result (audio/video URLs) */
+export interface FileResult extends MediaResult {
+	provider: 'file'
+	/** 'audio' or 'video' based on file extension */
+	kind: 'audio' | 'video'
 }
 
 /** Result of parsing an "Artist - Title" string */


### PR DESCRIPTION
Now parseUrl() and getMedia() supports file urls. They'll return

```js
const FileResult = {provider: 'file', kind: 'audio' | 'video'}
```